### PR TITLE
Transfer the repository to TNO on GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 the name of your source branch. `target branch` <- merge - `source branch`.
 The badge will show the coverage after the first CI run has been completed.
 If you do not want to display the coverage, just remove the line below. -->
-![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rozsasarpi/bafe6e5b1382e4c2c49156a01e4803f3/raw/lightkde_$your_source_branch_name$_coverage.json)
+![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rozsasarpi/bafe6e5b1382e4c2c49156a01e4803f3/raw/59d039ed1e8228f8e5faad495c96a51df6db1173/lightkde_$your_source_branch_name$_coverage.json)

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -94,7 +94,7 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.repository == 'rozsasarpi/lightkde'
+    if: github.ref == 'refs/heads/main' && github.repository == 'TNO/lightkde'
     concurrency: release
     needs: [ lint_and_type_check, test ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ## v1.0.1 (2021-11-22)
 ### Fix
-* **docs:** Resolve dependency conflict between furo and sphinx ([`1320719`](https://github.com/rozsasarpi/lightkde/commit/1320719a31e3f33bcb889d923f65c50dc0f0b9cf))
+* **docs:** Resolve dependency conflict between furo and sphinx ([`1320719`](https://github.com/TNO/lightkde/commit/1320719a31e3f33bcb889d923f65c50dc0f0b9cf))
 
 ### Documentation
-* Add a cleaner html title to docs ([`7f2d149`](https://github.com/rozsasarpi/lightkde/commit/7f2d149ddfeb1834653b33b9d67ec4eefea6c84c))
-* Fix and extend README.md badges ([`954e819`](https://github.com/rozsasarpi/lightkde/commit/954e81922153d09af829dec2ac8e7d595cfd716c))
+* Add a cleaner html title to docs ([`7f2d149`](https://github.com/TNO/lightkde/commit/7f2d149ddfeb1834653b33b9d67ec4eefea6c84c))
+* Fix and extend README.md badges ([`954e819`](https://github.com/TNO/lightkde/commit/954e81922153d09af829dec2ac8e7d595cfd716c))
 
 ## v1.0.0 (2021-07-23)
 ### Feature
-* Add initial version ([`b300a32`](https://github.com/rozsasarpi/lightkde/commit/b300a32befcd9a967e751cbdb8c0c2027ce89441))
+* Add initial version ([`b300a32`](https://github.com/TNO/lightkde/commit/b300a32befcd9a967e751cbdb8c0c2027ce89441))
 
 ### Breaking
-* initial version with all the base functionalities ([`b300a32`](https://github.com/rozsasarpi/lightkde/commit/b300a32befcd9a967e751cbdb8c0c2027ce89441))
+* initial version with all the base functionalities ([`b300a32`](https://github.com/TNO/lightkde/commit/b300a32befcd9a967e751cbdb8c0c2027ce89441))

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Árpád Rózsás
+Copyright (c) 2021 TNO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lightkde
 
 [![Documentation Status](https://readthedocs.org/projects/lightkde/badge/?version=stable)](https://lightkde.readthedocs.io/en/stable/)
-[![Continuous integration](https://github.com/rozsasarpi/lightkde/actions/workflows/push.yaml/badge.svg)](https://github.com/rozsasarpi/lightkde/actions)
+[![Continuous integration](https://github.com/TNO/lightkde/actions/workflows/push.yaml/badge.svg)](https://github.com/TNO/lightkde/actions)
 [![PyPI version](https://img.shields.io/pypi/v/lightkde)](https://pypi.org/project/lightkde/)
 ![python versions](https://img.shields.io/pypi/pyversions/lightkde)
 [![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rozsasarpi/bafe6e5b1382e4c2c49156a01e4803f3/raw/lightkde_main_coverage.json)](https://en.wikipedia.org/wiki/Code_coverage)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ now = datetime.datetime.now()
 # -- Project information -----------------------------------------------------
 
 project = "lightkde"
-copyright = f"{now.year}, Arpad Rozsas"
+copyright = f"{now.year}, TNO"
 author = "Arpad Rozsas"
 
 # The full version, including alpha/beta/rc tags

--- a/docs/for_contributors.md
+++ b/docs/for_contributors.md
@@ -6,7 +6,7 @@
 All contributions are welcome, feel free to make a pull
 request on [GitHub][github_repository].
 
-[github_repository]: https://github.com/rozsasarpi/lightkde
+[github_repository]: https://github.com/TNO/lightkde
 
 * Semantic versioning and automatic release using
   [python-semantic-release](https://github.com/relekang/python-semantic-release).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,4 +28,4 @@ pip install -e .[tests,lint_type_checks,docs]
 ```
 ````
 
-[repository]: https://github.com/rozsasarpi/lightkde
+[repository]: https://github.com/TNO/lightkde

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author_email = rozsasarpi@gmail.com
 description = Lightning fast, lightweight, and reliable kernel density estimation.
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/rozsasarpi/lightkde
+url = https://github.com/TNO/lightkde
 classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python :: 3.6


### PR DESCRIPTION
<!-- To get a coverage badge: change `$your_source_branch_name$` in the URL below to
the name of your source branch. `target branch` <- merge - `source branch`.
The badge will show the coverage after the first CI run has been completed.
If you do not want to display the coverage, just remove the line below. -->
![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rozsasarpi/bafe6e5b1382e4c2c49156a01e4803f3/raw/59d039ed1e8228f8e5faad495c96a51df6db1173/lightkde_transfer_coverage.json)



* `rozsasarpi` -> `TNO`
* change links and references
* what remains:
  - `gist` is still associated with `rozsasarpi`
  - LGTM still point to `rozsasarpi/lightkde` but that is automatically redirected to `TNO/lightkde` 
